### PR TITLE
Fix links

### DIFF
--- a/docs/c.md
+++ b/docs/c.md
@@ -6,10 +6,10 @@ It uses the `.eh_frame` section in ELF binaries to perform unwinding of stacks.
 
 ## Symbolization
 
-For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](uploading-debuginfos).
+For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](/docs/uploading-debuginfos).
 
 :::tip
-We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
+We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](/docs/uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
 :::
 
 To generate debuginfos use the `-g` flag.
@@ -42,4 +42,4 @@ strip --only-keep-debug main.debug # creates the main.debug file containing debu
 strip --strip-debug --strip-unneeded # removes the debuginfo sections from the binary
 ```
 
-The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.
+The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](/docs/uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.

--- a/docs/cpp.md
+++ b/docs/cpp.md
@@ -6,10 +6,10 @@ It uses the `.eh_frame` section in ELF binaries to perform unwinding of stacks.
 
 ## Symbolization
 
-For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](uploading-debuginfos).
+For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](/docs/uploading-debuginfos).
 
 :::tip
-We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
+We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](/docs/uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
 :::
 
 To generate debuginfos use the `-g` flag.
@@ -42,4 +42,4 @@ strip --only-keep-debug main.debug # creates the main.debug file containing debu
 strip --strip-debug --strip-unneeded # removes the debuginfo sections from the binary
 ```
 
-The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.
+The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](/docs/uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -14,7 +14,7 @@ node --perf-basic-prof --interpreted-frames-native-stack main.js
 
 ## Troubleshooting
 
-Below are some situations and how to troubleshoot them. If you've tried these and still haven't been able to resolve the issue, please [contact support](contact-support).
+Below are some situations and how to troubleshoot them. If you've tried these and still haven't been able to resolve the issue, please [contact support](/docs/contact-support).
 
 ### All I can see is memory addresses
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,34 +9,34 @@ Thanks to our zero-instrumentation technology all you do is deploy our agent on 
 
 If you're here to understand what the Polar Signals Cloud product is, we recommend reading:
 
-1. [What is Continuous Profiling?](what-is-continuous-profiling)
-2. [Why Polar Signals Cloud](why-polar-signals)
+1. [What is Continuous Profiling?](/docs/what-is-continuous-profiling)
+2. [Why Polar Signals Cloud](/docs/why-polar-signals)
 
 ### I already use Polar Signals Cloud
 
 Language Support:
 
-1. [C](c)/[C++](cpp)
-1. [Rust](rust)
-1. [Go](go)
+1. [C](/docs/c)/[C++](/docs/cpp)
+1. [Rust](/docs/rust)
+1. [Go](/docs/go)
 1. Ruby
 1. Python
 1. Java/Clojure/Kotlin/JVM
-1. [Node.js](nodejs)
+1. [Node.js](/docs/nodejs)
 1. Erlang
 1. Julia
 1. .NET
 
 Setup Collection:
 
-1. [Setup collection with Kubernetes](setup-collection-kubernetes)
+1. [Setup collection with Kubernetes](/docs/setup-collection-kubernetes)
 
 User Management:
 
-1. [Organizations and Projects](organizations-and-projects)
-2. [Inviting Users to an Org](invite-users)
+1. [Organizations and Projects](/docs/organizations-and-projects)
+2. [Inviting Users to an Org](/docs/invite-users)
 
 Miscellaneous:
 
-1. [Generating Tokens](generating-tokens)
-2. [Uploading Debuginfos](uploading-debuginfos)
+1. [Generating Tokens](/docs/generating-tokens)
+2. [Uploading Debuginfos](/docs/uploading-debuginfos)

--- a/docs/rust.md
+++ b/docs/rust.md
@@ -6,10 +6,10 @@ It uses the `.eh_frame` section in ELF binaries to perform unwinding of stacks.
 
 ## Symbolization
 
-For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](uploading-debuginfos).
+For memory addresses to be translated to human readable function names, file names, and line numbers, Polar Signals Cloud must be provided with what is referred to as "debuginfos". Debuginfos can be part of the production binary, or can be [uploaded separately in CI/CD pipelines](/docs/uploading-debuginfos).
 
 :::tip
-We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
+We recommend having debuginfos available in production binaries. Everything will just work out of the box without having to [upload the debuginfo separately in CI/CD pipelines](/docs/uploading-debuginfos), and it's always a good idea to have your binaries be debuggable for when the time comes.
 :::
 
 To generate debuginfos use the `-C debuginfo=2` flag (or [`-g` which is an alias for it](https://doc.rust-lang.org/rustc/command-line-arguments.html#option-g-debug)). Any value [starting at `line-tables-only` is sufficient](https://doc.rust-lang.org/rustc/codegen-options/index.html#debuginfo), but we recommend having the best quality debuginfos available (which is `2` or `full`).
@@ -43,4 +43,4 @@ strip --only-keep-debug main.debug # creates the main.debug file containing debu
 strip --strip-debug --strip-unneeded # removes the debuginfo sections from the binary
 ```
 
-The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.
+The `main.debug` could now be [uploaded separately in a CI/CD pipeline to Polar Signals Cloud](/docs/uploading-debuginfos). If debuginfos are available in the production binary this step is not necessary.

--- a/docs/setup-scraper.mdx
+++ b/docs/setup-scraper.mdx
@@ -1,6 +1,6 @@
 # Setup Scraping for sending to Polar Signals Cloud
 
-While the primary way to write data to Polar Signals Cloud is to [use the agent](setup-collection-kubernetes), there may be reasons to want to write additional data that cannot be obtained via the agent.
+While the primary way to write data to Polar Signals Cloud is to [use the agent](/docs/setup-collection-kubernetes), there may be reasons to want to write additional data that cannot be obtained via the agent.
 
 ## Languages
 

--- a/docs/upload-source.mdx
+++ b/docs/upload-source.mdx
@@ -13,7 +13,7 @@ We recommend doing the following in a CI/CD pipeline.
 
 ## Prerequisites
 
-* [An authentication token](generating-tokens.mdx)
+* [An authentication token](/docs/generating-tokens.mdx)
 * [parca-debuginfo](https://github.com/parca-dev/parca-debuginfo)
 
 ### Install `parca-debuginfo`

--- a/docs/what-is-continuous-profiling.md
+++ b/docs/what-is-continuous-profiling.md
@@ -16,7 +16,7 @@ After some time, typically 10 seconds, the data is saved and can be analyzed usi
 Because of high sampling rates being necessary for 10 seconds of data to be representative profiling traditionally adds a lot of overhead to a process,
 which is why it tends to be done one-off only during development or on an ad-hoc basis.
 
-Understand profiling in more depth in our [Profiling 101](profiling-101).
+Understand profiling in more depth in our [Profiling 101](/docs/profiling-101).
 
 ## What is Continuous Profiling?
 
@@ -25,5 +25,5 @@ Continuous Profiling takes the opposite trade-off, it profiles every process in 
 Doing this allows continuous profiling to gather enough data to build statistical significance over time, and with **very low overhead** (less than 1% with the Polar Signals Agent).
 
 Fortunately, because continuous profiling stores profiling data over time, new workflows are possible. 
-See [Why Polar Signals](why-polar-signals#what-can-i-do-with-polar-signals-cloud) to learn why you should do continuous profiling with Polar Signals Cloud.
+See [Why Polar Signals](/docs/why-polar-signals#what-can-i-do-with-polar-signals-cloud) to learn why you should do continuous profiling with Polar Signals Cloud.
 

--- a/docs/why-polar-signals.md
+++ b/docs/why-polar-signals.md
@@ -10,7 +10,7 @@ You just want to see the demo? Check out our demos in our [Polar Signals Cloud Y
 
 ## What is Continuous Profiling?
 
-If you're not already familiar with Continuous Profiling, you might want to read our primer on it first: [What is Continuous Profiling?](what-is-continuous-profiling)
+If you're not already familiar with Continuous Profiling, you might want to read our primer on it first: [What is Continuous Profiling?](/docs/what-is-continuous-profiling)
 
 ## Polar Signals Cloud vs. Parca
 


### PR DESCRIPTION
We allow trailing slashes which causes relative links to break, so this patch changes all links to be absolute.