### PR TITLE
nodejs: Adjust flag

### DIFF
--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -3,13 +3,13 @@
 [Node.js](https://nodejs.org) is a popular platform to write server-side applications.
 Profiling Node.js based application is supported out of the box with Polar Signals Cloud.
 
-To see function names for Javascript code the `--perf-basic-prof` flag must be passed to the `node` command. 
+To see function names for Javascript code the `--perf-basic-prof-only-functions` flag must be passed to the `node` command. 
 For better quality we also recommend to pass the `--interpreted-frames-native-stack` flag.
 
 For example the full command might look like this:
 
 ```bash
-node --perf-basic-prof --interpreted-frames-native-stack main.js
+node --perf-basic-prof-only-functions --interpreted-frames-native-stack main.js
 ```
 
 ## Troubleshooting
@@ -18,7 +18,7 @@ Below are some situations and how to troubleshoot them. If you've tried these an
 
 ### All I can see is memory addresses
 
-First make sure the node process is started with the `--perf-basic-prof` and `--interpreted-frames-native-stack` flags.
+First make sure the node process is started with the `--perf-basic-prof-only-functions` and `--interpreted-frames-native-stack` flags.
 Then check that the process is successfully writing a perfmap. 
 By default, perfmaps are written to `/tmp/perf-<PID>.map`.
 


### PR DESCRIPTION
The previous flag works, but emits way more information than needed for profiling purposes, which causes larger perf map files on the filesystem and in turm larger memory usage by an agent reading it.