### PR TITLE
docs: add collection docs for parca-agent snap

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -32,6 +32,7 @@ Language Support:
 Setup Collection:
 
 1. [Setup collection with Kubernetes](/docs/setup-collection-kubernetes)
+2. [Setup collection with Snaps](/docs/setup-collection-snaps)
 
 User Management:
 

--- a/docs/setup-collection-snaps.mdx
+++ b/docs/setup-collection-snaps.mdx
@@ -1,0 +1,38 @@
+# Setup collection using Snaps
+
+## Prerequisites:
+
+- Linux 5.4 or newer.
+- [snapd](https://snapcraft.io/about)
+
+### Get an API token
+
+To be able to send any data to Polar Signals Cloud, we're going to need an API token for the
+collection mechanism to authenticate with the Polar Signals API.
+
+Please refer to the [Generating Tokens](/docs/generating-tokens) documentation that has more details.
+
+### Bootstrap with cloud-init
+
+If you're on a cloud or hypervisor that supports [`cloud-init`](https://cloudinit.readthedocs.io/en/latest/index.html) you can get started easily like so:
+
+```yaml
+#cloud-config
+snap:
+  commands:
+    - [install, parca-agent, --classic]
+    - [set, parca-agent, remote-store-bearer-token=<token>]
+    - [start, --enable, parca-agent]
+```
+
+### Install manually
+
+To setup collection on a machine that's already provisioned, use the following steps:
+
+```shell
+sudo snap install parca-agent --classic
+sudo snap set parca-agent remote-store-bearer-token=<token>
+sudo snap start --enable parca-agent
+```
+
+Learn more about the Parca Agent snap in the [Parca docs](https://www.parca.dev/docs/parca-agent-snap).

--- a/sidebars.js
+++ b/sidebars.js
@@ -78,6 +78,7 @@ const sidebars = {
       items: [
         "setup-collection-kubernetes",
         "setup-collection-docker",
+        "setup-collection-snaps",
         "invite-users",
         "generating-tokens",
         "uploading-debuginfos",


### PR DESCRIPTION
Add docs for onboarding collectors with snaps & cloud-init.

Of particular interest in my view is this piece of cloud-init which should work on any ubuntu machine, on any cloud:

```yaml
#cloud-config
snap:
  commands:
    - [install, parca-agent, --classic]
    - [set, parca-agent, remote-store-bearer-token=<token>]
    - [start, --enable, parca-agent]
```