### PR TITLE
Remove --enable flags for Python and Ruby

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -1,12 +1,5 @@
 # Python Support
 
-:::note
-Python profiling is currently in beta. There are some known CPU spikes in the agent that can occur when enabling Python profiling, once those are fixes Python support will no longer be in beta. The CPU spikes are not fatal, but we have a high bar for features we enable by default.
-:::
-
-To enable profiling Python code enable the `--enable-python-unwinding` flag in the Polar Signals Agent.
-
-
 :::info
 In order to profile Python code you must have an interpreter with **symbols**.
 :::

--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -1,11 +1,5 @@
 # Ruby Support
 
-:::note
-Ruby profiling is currently in beta. There are some known CPU spikes in the agent that can occur when enabling Ruby profiling, once those are fixes Ruby support will no longer be in beta. The CPU spikes are not fatal, but we have a high bar for features we enable by default.
-:::
-
-To enable profiling Ruby code enable the `--enable-ruby-unwinding` flag.
-
 :::info
 In order to profile Ruby code you must have an interpreter with **symbols**.
 :::


### PR DESCRIPTION
Both interpreters are supported by default now.
